### PR TITLE
feat: add email details navigation functionality

### DIFF
--- a/ainbox/ainbox.Shared/Pages/EmailDetail.razor
+++ b/ainbox/ainbox.Shared/Pages/EmailDetail.razor
@@ -118,8 +118,19 @@
 
             client.Disconnect(true);
         }
-        catch (Exception)
+        catch (ImapProtocolException ex)
         {
+            Console.WriteLine($"IMAP protocol error: {ex.Message}");
+            emailMessage = null;
+        }
+        catch (AuthenticationException ex)
+        {
+            Console.WriteLine($"Authentication error: {ex.Message}");
+            emailMessage = null;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Unexpected error: {ex.Message}");
             emailMessage = null;
         }
     }

--- a/ainbox/ainbox.Shared/Pages/EmailDetail.razor
+++ b/ainbox/ainbox.Shared/Pages/EmailDetail.razor
@@ -1,0 +1,131 @@
+@page "/email/{EmailId}"
+@using MailKit
+@using MailKit.Net.Imap
+@using MimeKit
+@using ainbox.Shared.Services
+@inject ISettingsService SettingsService
+@inject NavigationManager Navigation
+
+<PageTitle>Email Details</PageTitle>
+
+<div>
+    <button class="btn btn-primary mb-3" @onclick="GoBack">← Back to Inbox</button>
+
+    @if (isLoading)
+    {
+        <div>Loading email...</div>
+    }
+    else if (emailMessage != null)
+    {
+        <div class="card">
+            <div class="card-header">
+                <h3>@emailMessage.Subject</h3>
+            </div>
+            <div class="card-body">
+                <div class="row mb-2">
+                    <div class="col-2"><strong>From:</strong></div>
+                    <div class="col-10">@emailMessage.From</div>
+                </div>
+                <div class="row mb-2">
+                    <div class="col-2"><strong>To:</strong></div>
+                    <div class="col-10">@emailMessage.To</div>
+                </div>
+                <div class="row mb-2">
+                    <div class="col-2"><strong>Date:</strong></div>
+                    <div class="col-10">@emailMessage.Date.ToString("f")</div>
+                </div>
+                <hr />
+                <div class="email-body">
+                    @if (!string.IsNullOrEmpty(emailMessage.HtmlBody))
+                    {
+                        @((MarkupString)emailMessage.HtmlBody)
+                    }
+                    else if (!string.IsNullOrEmpty(emailMessage.TextBody))
+                    {
+                        <pre style="white-space: pre-wrap; font-family: inherit;">@emailMessage.TextBody</pre>
+                    }
+                    else
+                    {
+                        <div>No email content available.</div>
+                    }
+                </div>
+            </div>
+        </div>
+    }
+    else
+    {
+        <div class="alert alert-danger">Email not found or error loading email.</div>
+    }
+</div>
+
+@code {
+    [Parameter] public string EmailId { get; set; } = string.Empty;
+
+    private DetailedEmailMessage? emailMessage;
+    private bool isLoading = true;
+    private string? username;
+    private string? password;
+
+    public class DetailedEmailMessage
+    {
+        public required string Subject { get; set; }
+        public required string From { get; set; }
+        public required string To { get; set; }
+        public required DateTimeOffset Date { get; set; }
+        public string? HtmlBody { get; set; }
+        public string? TextBody { get; set; }
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        username = await SettingsService.GetSetting("Username");
+        password = await SettingsService.GetSetting("Password");
+
+        if (username != null && password != null && !string.IsNullOrEmpty(EmailId))
+        {
+            await LoadEmailContent();
+        }
+
+        isLoading = false;
+    }
+
+    private async Task LoadEmailContent()
+    {
+        try
+        {
+            if (!uint.TryParse(EmailId, out uint uid))
+                return;
+
+            using var client = new ImapClient();
+            client.Connect("imap.gmail.com", 993, true);
+            await client.AuthenticateAsync(username!, password!);
+
+            var inbox = client.Inbox;
+            inbox.Open(MailKit.FolderAccess.ReadOnly);
+
+            var uniqueId = new UniqueId(uid);
+            var message = inbox.GetMessage(uniqueId);
+
+            emailMessage = new DetailedEmailMessage
+            {
+                Subject = message.Subject ?? "No Subject",
+                From = message.From.ToString(),
+                To = message.To.ToString(),
+                Date = message.Date,
+                HtmlBody = message.HtmlBody,
+                TextBody = message.TextBody
+            };
+
+            client.Disconnect(true);
+        }
+        catch (Exception)
+        {
+            emailMessage = null;
+        }
+    }
+
+    private void GoBack()
+    {
+        Navigation.NavigateTo("/");
+    }
+}

--- a/ainbox/ainbox.Shared/Pages/EmailDetail.razor
+++ b/ainbox/ainbox.Shared/Pages/EmailDetail.razor
@@ -3,6 +3,7 @@
 @using MailKit.Net.Imap
 @using MimeKit
 @using ainbox.Shared.Services
+@using Ganss.Xss
 @inject ISettingsService SettingsService
 @inject NavigationManager Navigation
 
@@ -38,7 +39,7 @@
                 <div class="email-body">
                     @if (!string.IsNullOrEmpty(emailMessage.HtmlBody))
                     {
-                        @((MarkupString)emailMessage.HtmlBody)
+                        @((MarkupString)SanitizeHtml(emailMessage.HtmlBody))
                     }
                     else if (!string.IsNullOrEmpty(emailMessage.TextBody))
                     {
@@ -122,6 +123,39 @@
         {
             emailMessage = null;
         }
+    }
+
+    private string SanitizeHtml(string htmlContent)
+    {
+        var sanitizer = new HtmlSanitizer();
+
+        // Configure allowed tags for email content
+        sanitizer.AllowedTags.Clear();
+        sanitizer.AllowedTags.UnionWith(new[] {
+            "p", "div", "span", "br", "hr", "h1", "h2", "h3", "h4", "h5", "h6",
+            "strong", "b", "em", "i", "u", "s", "sub", "sup",
+            "ul", "ol", "li", "blockquote", "pre", "code",
+            "a", "img", "table", "thead", "tbody", "tr", "td", "th"
+        });
+
+        // Configure allowed attributes
+        sanitizer.AllowedAttributes.Clear();
+        sanitizer.AllowedAttributes.UnionWith(new[] {
+            "href", "title", "alt", "src", "width", "height", "style"
+        });
+
+        // Allow safe CSS properties
+        sanitizer.AllowedCssProperties.Clear();
+        sanitizer.AllowedCssProperties.UnionWith(new[] {
+            "color", "background-color", "font-size", "font-family", "font-weight",
+            "text-align", "margin", "padding", "border", "width", "height"
+        });
+
+        // Remove dangerous schemes
+        sanitizer.AllowedSchemes.Clear();
+        sanitizer.AllowedSchemes.UnionWith(new[] { "http", "https", "mailto" });
+
+        return sanitizer.Sanitize(htmlContent);
     }
 
     private void GoBack()

--- a/ainbox/ainbox.Shared/Pages/Inbox.razor
+++ b/ainbox/ainbox.Shared/Pages/Inbox.razor
@@ -4,6 +4,7 @@
 @using MailKit.Search
 @using ainbox.Shared.Services
 @inject ISettingsService SettingsService
+@inject NavigationManager Navigation
 
 <PageTitle>Inbox</PageTitle>
 
@@ -20,10 +21,19 @@ else
         <p>Recent messages: @inboxRecent</p>
         <p>First subject: @subject</p>
 
-        <ul>
-            @foreach(var f in folders)
+        <ul class="list-group">
+            @foreach(var email in emails)
             {
-                <li>@f</li>
+                <li class="list-group-item list-group-item-action" style="cursor: pointer;" @onclick="() => NavigateToEmail(email.UniqueId)">
+                    <div class="d-flex justify-content-between">
+                        <div>
+                            <h6 class="mb-1">@email.Subject</h6>
+                            <p class="mb-1">@email.Sender</p>
+                            <small>@email.Preview</small>
+                        </div>
+                        <small>@email.Date.ToString("MMM dd")</small>
+                    </div>
+                </li>
             }
         </ul>
 }
@@ -32,7 +42,7 @@ else
     private int? inboxCount;
     private int? inboxRecent;
     private string subject;
-    private List<string> folders = new List<string>();
+    private List<EmailMessage> emails = new List<EmailMessage>();
 
     private string? username;
     private string? password;
@@ -68,7 +78,14 @@ else
                 // Display the ordered messages
                 foreach (var message in orderedMessages)
                 {
-                    folders.Add($"{message.Envelope.Date}: {message.Envelope.Subject}");
+                    emails.Add(new EmailMessage
+                    {
+                        Subject = message.Envelope.Subject ?? "No Subject",
+                        Sender = message.Envelope.From.FirstOrDefault()?.Name ?? message.Envelope.From.FirstOrDefault()?.ToString() ?? "Unknown Sender",
+                        Date = message.Envelope.Date ?? DateTimeOffset.Now,
+                        UniqueId = message.UniqueId,
+                        Preview = $"{message.Envelope.Date}: {message.Envelope.Subject}"
+                    });
                 }
 
                 // Disconnect from the server
@@ -77,5 +94,10 @@ else
         }
 
         await base.OnInitializedAsync();
+    }
+
+    private void NavigateToEmail(UniqueId emailId)
+    {
+        Navigation.NavigateTo($"/email/{emailId.Id}");
     }
 }

--- a/ainbox/ainbox.Shared/Services/EmailMessage.cs
+++ b/ainbox/ainbox.Shared/Services/EmailMessage.cs
@@ -1,0 +1,12 @@
+using MailKit;
+
+namespace ainbox.Shared.Services;
+
+public class EmailMessage
+{
+    public required string Subject { get; set; }
+    public required string Sender { get; set; }
+    public required DateTimeOffset Date { get; set; }
+    public required UniqueId UniqueId { get; set; }
+    public required string Preview { get; set; }
+}

--- a/ainbox/ainbox.Shared/ainbox.Shared.csproj
+++ b/ainbox/ainbox.Shared/ainbox.Shared.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="HtmlSanitizer" Version="9.0.886" />
     <PackageReference Include="MailKit" Version="4.13.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.7" />
   </ItemGroup>


### PR DESCRIPTION
- Add EmailMessage model for structured email data
- Create EmailDetail page with route /email/{id} for viewing full email content
- Update Inbox page to display structured email list with click navigation
- Implement email content fetching using MailKit
- Add back navigation from detail view to inbox

🤖 Generated with [Claude Code](https://claude.ai/code)